### PR TITLE
Fix RemovedInDjango41Warning for app config

### DIFF
--- a/webpack_boilerplate/__init__.py
+++ b/webpack_boilerplate/__init__.py
@@ -1,1 +1,7 @@
-default_app_config = "webpack_boilerplate.apps.WebpackBoilerplateConfig"
+try:
+    import django
+except ImportError:
+    pass
+else:
+    if django.VERSION < (3, 2):
+        default_app_config = "webpack_boilerplate.apps.WebpackBoilerplateConfig"


### PR DESCRIPTION
Fix this warning:

```
  /.../django/apps/registry.py:91: RemovedInDjango41Warning: 'webpack_boilerplate' defines default_app_config = 'webpack_boilerplate.apps.WebpackBoilerplateConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)
```

As per: https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery