### PR TITLE
Add ``--no-input`` command line argument.

### DIFF
--- a/webpack_boilerplate/management/commands/webpack_init.py
+++ b/webpack_boilerplate/management/commands/webpack_init.py
@@ -4,8 +4,18 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--no-input',
+            action='store_true',
+            help='Do not ask for input.',
+        )
+
     def handle(self, *args, **options):
         from cookiecutter.main import cookiecutter
-
         pkg_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        cookiecutter(pkg_path, directory="frontend_template")
+        if options['no_input']:
+            cookiecutter(pkg_path, directory="frontend_template", no_input=True)
+        else:
+        	cookiecutter(pkg_path, directory="frontend_template")

--- a/webpack_boilerplate/management/commands/webpack_init.py
+++ b/webpack_boilerplate/management/commands/webpack_init.py
@@ -18,4 +18,4 @@ class Command(BaseCommand):
         if options['no_input']:
             cookiecutter(pkg_path, directory="frontend_template", no_input=True)
         else:
-        	cookiecutter(pkg_path, directory="frontend_template")
+            cookiecutter(pkg_path, directory="frontend_template")


### PR DESCRIPTION
Add ``--no-input`` command line argument to suppress command line prompt. https://cookiecutter.readthedocs.io/en/2.0.2/advanced/suppressing_prompts.html#suppressing-command-line-prompts