### PR TITLE
refactor entries generation to generate entries names independently f…

### DIFF
--- a/webpack_boilerplate/frontend_template/{{cookiecutter.project_slug}}/webpack/webpack.common.js
+++ b/webpack_boilerplate/frontend_template/{{cookiecutter.project_slug}}/webpack/webpack.common.js
@@ -6,9 +6,13 @@ const WebpackAssetsManifest = require("webpack-assets-manifest");
 
 const getEntryObject = () => {
   const entries = {};
-  glob.sync(Path.join(__dirname, "../src/application/*.js")).forEach((path) => {
-    const name = Path.basename(path, ".js");
-    entries[name] = path;
+  glob.sync(Path.join(__dirname, "../src/application/*.{js}")).forEach((path) => {
+
+    const name = Path.basename(path);
+    const extension = Path.extname(path);
+    const entryName = name.replace(extension, '');
+
+    entries[entryName] = path;
   });
   return entries;
 };


### PR DESCRIPTION
This makes it easier to extend this function to handle multiple file extensions by editing the path, e.g. like this: 
`../src/application/*.{js,jsx,ts,tsx}`

targeting the typescript refactoring in this tutorial: https://www.accordbox.com/blog/how-to-add-typescript-to-the-django-project/

Feedback appreciated